### PR TITLE
Fix camera orbit and zoom behavior

### DIFF
--- a/js/CameraManager.js
+++ b/js/CameraManager.js
@@ -109,7 +109,7 @@ class CameraManager {
         const targetLookAt = new THREE.Vector3();
         planet.getWorldPosition(targetLookAt);
 
-        const distance = Math.max(planet.userData.size * 3, 20);
+        const distance = planet.userData.size * 2.5;
         const direction = new THREE.Vector3().subVectors(this.camera.position, targetLookAt).normalize();
         const endPosition = new THREE.Vector3().addVectors(targetLookAt, direction.multiplyScalar(distance));
 
@@ -153,7 +153,18 @@ class CameraManager {
         } else if (this.focusedPlanet && !this.isTransitioning) {
             const targetPosition = new THREE.Vector3();
             this.focusedPlanet.getWorldPosition(targetPosition);
+
+            // Before OrbitControls updates the camera based on user input,
+            // we calculate the camera's current offset from the target.
+            const offset = new THREE.Vector3().subVectors(this.camera.position, this.orbitControls.target);
+
+            // Then, we update the target to the planet's new position.
             this.orbitControls.target.copy(targetPosition);
+
+            // And finally, we re-apply the offset to the new target position.
+            // This effectively moves the camera with the planet.
+            this.camera.position.copy(this.orbitControls.target).add(offset);
+
             this.orbitControls.update();
         }
     }


### PR DESCRIPTION
This commit addresses two issues with the camera when focusing on a planet:

1.  **Camera Orbit:** When orbiting a planet, the camera would appear to lose its distance from the planet during the orbit and then snap back into place. This was because the camera's position was not being correctly updated relative to the moving planet during the orbit. The `update` method in `CameraManager.js` has been modified to manually calculate the camera's offset from the orbit target, update the target's position, and then re-apply the offset to the camera's position before updating the orbit controls. This ensures the camera smoothly follows the planet while orbiting.

2.  **Camera Zoom:** When focusing on a planet, the camera was too far away to appreciate the details. The distance calculation in `moveCameraToPlanet` in `CameraManager.js` has been adjusted to bring the camera closer to the planet's surface.